### PR TITLE
fix(simpleedit/begin_regex): reference " is optional

### DIFF
--- a/src/mcp_simpleedit.lua
+++ b/src/mcp_simpleedit.lua
@@ -3,7 +3,7 @@
 --
 -- Author: lisdude <lisdude@lisdude.com>
 --
-local edit_begin_regex = "^#\\$#dns-org-mud-moo-simpleedit-content (\\d{20}) reference: (\".+\") name: (\"?.*\"?) type: (.+) content\\*: (\".*\") _data-tag: (.+)$"
+local edit_begin_regex = "^#\\$#dns-org-mud-moo-simpleedit-content (\\d{20}) reference: (\"?.+\"?) name: (\"?.*\"?) type: (.+) content\\*: (\".*\") _data-tag: (.+)$"
 local edit_content_regex = "^#\\$#\\* (.+) content:[ ]?(.*)$"
 local edit_end_regex = "^#\\$#: (.+)$"
 


### PR DESCRIPTION
This was breaking `@send` on ChatMUD.