### PR TITLE
Fix shell injection in call to os.execute

### DIFF
--- a/src/lambdamoo_simpleedit.lua
+++ b/src/lambdamoo_simpleedit.lua
@@ -44,7 +44,7 @@ function lambdamoo_timeout_old_edits()
             currently_editing[path] = nil
         elseif data[1] ~=0 and (current_time - last_modified) >= mcp_settings["simpleedit_timeout"] then
 --            data[1]:close()
-            os.execute("rm \"" .. path .. "\"")
+            core.exec({"rm", path})
             if mcp_settings["debug_mcp"] then
                 blight.output(C_BCYAN .. ">>> " .. C_YELLOW .. "LambdaMOO edit deleted editor file " .. path .. C_RESET)
             end
@@ -69,9 +69,8 @@ function lambdamoo_simpleedit_capture(data)
         trigger.remove(current_capture[1].id)
         currently_editing[path][1] = last_modified(path)
         local edit_data = currently_editing[path]
-        local edit_cmd = mcp_settings["edit_command"]:gsub("%%FILE", path)
-        edit_cmd = edit_cmd:gsub("%%NAME", edit_data[2])
-        os.execute(edit_cmd)
+        local edit_cmd = mcp_settings["edit_command"]
+        mcp_edit_file(edit_data[2], path)
         current_capture = {}
     else
         if data[1].sub(1, 2) == ".." then
@@ -86,7 +85,7 @@ end
 function lambdamoo_simpleedit_begin(data)
     local name = sanitize_name("\"" .. data[2] .. "\"")
     local command = data[3]
-    path = simpleedit_filename(mcp_settings["simpleedit_path"] .. sanitize_filename(data[2]))
+    local path = simpleedit_filename(mcp_settings["simpleedit_path"] .. sanitize_filename(data[2]))
     local handle = io.open(path, "w")
     if handle == nil then
         blight.output(C_BCYAN .. ">>> " .. BG_RED .. "Couldn't open file " .. path .. " for editing!" .. C_RESET)

--- a/src/mcp_simpleedit.lua
+++ b/src/mcp_simpleedit.lua
@@ -57,7 +57,7 @@ function timeout_old_edits()
             currently_editing[data_tag] = nil
         elseif data[3] ~=0 and (current_time - last_modified) >= mcp_settings["simpleedit_timeout"] then
 --            data[1]:close()
-            os.execute("rm \"" .. data[2] .. "\"")
+            os.exec({"rm", data[2]})
             if mcp_settings["debug_mcp"] then
                 blight.output(C_BCYAN .. ">>> " .. C_YELLOW .. "Simpleedit deleted editor file " .. data[2] .. C_RESET)
             end
@@ -82,11 +82,7 @@ function simpleedit_end(data)
     local edit_cmd = mcp_settings["edit_command"]
     local file_path = edit_data[2]
     local edit_name = edit_data[5]
-
-    edit_cmd = edit_cmd:gsub("%%FILE", file_path)
-    edit_cmd = edit_cmd:gsub("%%NAME", edit_name)
-
-    os.execute(edit_cmd)
+    mcp_edit_file(edit_name, file_path)
 end
 
 -- As MCP data is received, write it to the file we want to edit.
@@ -127,7 +123,7 @@ end
 function clear_editor()
     for data_tag, data in pairs(currently_editing) do
         if file_exists(data[2]) then
-            os.execute("rm \"" .. data[2] .. "\"")
+            core.exec({"rm", data[2]})
             currently_editing[data_tag] = nil
         end
     end

--- a/src/mcp_utils.lua
+++ b/src/mcp_utils.lua
@@ -115,6 +115,16 @@ function print_table(o)
    end
 end
 
+function mcp_edit_file(name, path)
+    local args = {}
+    for _, arg in ipairs(mcp_settings["edit_command"]) do
+        arg = arg:gsub("%%NAME", name):gsub("%%FILE", path)
+        table.insert(args, arg)
+    end
+    core.exec(args)
+end
+
+
 -- Delete all of the *.moo files in the simpleedit path.
 function delete_editor_files()
     os.execute("rm -f \"" .. mcp_settings["simpleedit_path"] .. "\"*.moo")

--- a/src/settings.lua
+++ b/src/settings.lua
@@ -1,20 +1,8 @@
--- Helper functions to make sure edit_command substitutions are properly quoted.
-local function is_quoted_placeholder(cmd, placeholder)
-    return cmd:match('%"' .. placeholder .. '%"') or cmd:match("%'" .. placeholder .. "%'")
-end
-
-local function ensure_quoted_placeholder(cmd, placeholder)
-    if not is_quoted_placeholder(cmd, placeholder) then
-        cmd = cmd:gsub(placeholder, '"' .. placeholder .. '"')
-    end
-    return cmd
-end
-
 -- Restore default settings and save them to disk.
 local function mcp_reset_defaults()
     local mcp_defaults = {
         simpleedit_path = plugin.dir("blightmud_mcp") .. "/simpleedit/",
-        edit_command = "vim -c \"set syntax=moo\" \"%FILE\"",
+        edit_command = {"vim", "-c", "set syntax=moo", "%FILE"},
         simpleedit_timeout = 10800,
         lambdamoo_connect_string = "\\*\\*\\* Connected \\*\\*\\*",
         debug_mcp = false
@@ -25,16 +13,17 @@ end
 -- Read settings from disk.
 function mcp_read_settings()
     mcp_settings = json.decode(store.disk_read("mcp_settings"))
+end
 
-    mcp_settings["edit_command"] = ensure_quoted_placeholder(mcp_settings["edit_command"], "%%FILE")
-    mcp_settings["edit_command"] = ensure_quoted_placeholder(mcp_settings["edit_command"], "%%NAME")
+local function format_value(v)
+    return type(v) == "table" and json.encode(v) or tostring(v)
 end
 
 -- Display MCP settings.
 function mcp_display_settings(args)
     if #args == 1 then
         for key, value in pairs(mcp_settings) do
-            blight.output("[mcp] " .. C_YELLOW .. key .. C_RESET .. " => " .. tostring(value))
+            blight.output("[mcp] " .. C_YELLOW .. key .. C_RESET .. " => " .. format_value(value))
         end
         blight.output("\nUse '/mcp defaults' to reset settings to defaults.")
     elseif args[2] == "defaults" then
@@ -45,7 +34,7 @@ function mcp_display_settings(args)
         if mcp_settings[args[2]] == nil then
             blight.output("[mcp] " .. C_RED .. " Setting doesn't exist " .. C_RESET)
         else
-            blight.output("[mcp] " .. C_YELLOW .. args[2] .. C_RESET .. " => " .. tostring(mcp_settings[args[2]]))
+            blight.output("[mcp] " .. C_YELLOW .. args[2] .. C_RESET .. " => " .. format_value(mcp_settings[args[2]]))
         end
     end
 end
@@ -61,12 +50,11 @@ function mcp_change_setting(args)
         elseif args[2] == "debug_mcp" then
             args[3] = args[3] == "true" and true or false
         elseif args[2] == "edit_command" then
-            args[3] = ensure_quoted_placeholder(args[3], "%%FILE")
-            args[3] = ensure_quoted_placeholder(args[3], "%%NAME")
+            args[3] = json.decode(args[3])
         end
         mcp_settings[args[2]] = args[3]
         store.disk_write("mcp_settings", json.encode(mcp_settings))
-        blight.output("[mcp] " .. C_YELLOW .. args[2] .. C_RESET .. " => " .. tostring(mcp_settings[args[2]]))
+        blight.output("[mcp] " .. C_YELLOW .. args[2] .. C_RESET .. " => " .. format_value(mcp_settings[args[2]]))
         if args[2] == "debug_mcp" or args[2] == "simpleedit_timeout" or args[2] == "lambdamoo_connect_string" then
             blight.output("[mcp] " .. C_CYAN .. "***" .. C_RESET .. " Changing this setting requires reloading the MCP plugin. " .. C_CYAN .. "***" .. C_RESET)
         end


### PR DESCRIPTION
An example of how to trigger the shell injection on LambdaMOO:
```text
;; player:tell("#$# edit name: foo $(hostname) bar upload: @foobar"); player:tell(".");
```
There is currently an attempt to sanitize the filename, but it doesn't catch this method of injection (or some others I can think of). Also, the correct sanitization is probably shell-specific, while `os.execute` doesn't specify which shell is used.

This patch instead uses the new `core.exec` variant in Blightmud v5.3.2 which accepts a table of arguments. This avoids the problem by not passing through a shell, instead executing the command directly.

I only tested this with LambdaMOO's simple edit; the patch changes the other edit implementation too, but I haven't tested it.

Users updating from an existing installation of `blightmud_mcp` should run `/mcp defaults` or set their edit command like so:
```text
/mcp edit_command ["emacsclient", "--quiet", "--no-wait", "%FILE"]
```