### PR TITLE
Fix call to core.exec in timeout_old_edits

### DIFF
--- a/src/mcp_simpleedit.lua
+++ b/src/mcp_simpleedit.lua
@@ -57,7 +57,7 @@ function timeout_old_edits()
             currently_editing[data_tag] = nil
         elseif data[3] ~=0 and (current_time - last_modified) >= mcp_settings["simpleedit_timeout"] then
 --            data[1]:close()
-            os.exec({"rm", data[2]})
+            core.exec({"rm", data[2]})
             if mcp_settings["debug_mcp"] then
                 blight.output(C_BCYAN .. ">>> " .. C_YELLOW .. "Simpleedit deleted editor file " .. data[2] .. C_RESET)
             end


### PR DESCRIPTION
Fixup of 12f3a5a0f52a3fc81691eaa1a40c7ec57f13adeb which replaced os.execute with core.exec